### PR TITLE
Use argument `duration` instead of `fps` in newer version of imageio

### DIFF
--- a/seg_track_anything.py
+++ b/seg_track_anything.py
@@ -215,7 +215,7 @@ def video_type_input_tracking(SegTracker, input_video, io_args, video_name, fram
     print('\nfinished')
 
     # save colorized masks as a gif
-    imageio.mimsave(io_args['output_gif'], masked_pred_list, fps=fps)
+    imageio.mimsave(io_args['output_gif'], masked_pred_list, duration=1000 / fps)
     print("{} saved".format(io_args['output_gif']))
 
     # zip predicted mask


### PR DESCRIPTION
```
TypeError: The keyword `fps` is no longer supported. Use `duration`(in ms) instead,
e.g. `fps=50` == `duration=20` (1000 * 1/50).
```