### PR TITLE
increment before assignment

### DIFF
--- a/SegTracker.py
+++ b/SegTracker.py
@@ -141,8 +141,9 @@ class SegTracker():
                 or obj_num > self.max_obj_num:
                 new_obj_mask[new_obj_mask==idx] = 0
             else:
-                new_obj_mask[new_obj_mask==idx] = obj_num
                 obj_num += 1
+                new_obj_mask[new_obj_mask==idx] = obj_num
+
         return new_obj_mask
         
     def restart_tracker(self):


### PR DESCRIPTION
Please let me know if this is correct:

The background / unlabeled part of a mask is index 0.

If you have two objects being tracked, they would be index 1 & 2 and 
`SegTracker.curr_idx` = 2

Then when  SegTracker.find_new_objs() finds one additional object, it should set the index in the resulting combined mask to `SegTracker.curr_idx` + 1 = 3

Currently the increment happens after assignment, so the third object incorrectly gets assigned `SegTracker.curr_idx` = 2

This might be the cause of https://github.com/z-x-yang/Segment-and-Track-Anything/issues/105